### PR TITLE
SVG Fixes

### DIFF
--- a/activity/activity-arithmetic.svg
+++ b/activity/activity-arithmetic.svg
@@ -7,6 +7,7 @@
 <svg
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    height="55px"
    id="Layer_1"
    version="1.1"


### PR DESCRIPTION
Tested with Ubuntu 20.04 sucrose package , The icon was not visible in home view with following error in log-
```gi.repository.GLib.Error: rsvg-error-quark: XML parse error: error code=201 (3) in (null):31:50: Namespace prefix sodipodi for ry on circle is not defined (0)```
