### PR TITLE
Add README for Arithmetic activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Arithmetic
+
+## Overview
+
+Arithmetic is a Sugar learning activity that presents timed arithmetic questions and tracks scores on a shared scoreboard. The activity provides small puzzle modules (addition, subtraction, multiplication, division and related problems) and is implemented as a GTK/Sugar activity.
+
+## Repository Contents
+
+- `arithmetic.py`: main activity implementation (UI, question scheduling, scoring, synchronization).
+- `activity/`: activity metadata (activity.info).
+- `puzzles/`: individual puzzle modules; each module provides a `get_problem(self, difficulty)` function.
+- `dobject/`: helper modules used by the activity (UI and synchronization helpers).
+- `po/`: translation files for multiple languages.
+- `setup.py`, `MANIFEST`, `NEWS`, `COPYING`, `COPYING.GPLv2`: packaging and licensing metadata.
+- `screenshots/`: example images used in the repository.
+
+## Usage
+
+This project is a Sugar activity and runs inside the Sugar learning environment as an activity bundle.
+
+## License
+
+This project is distributed under the terms of the GNU General Public License (GPL), see COPYING for details. The repository contains a GPL v2 license copy.

--- a/README.md
+++ b/README.md
@@ -2,22 +2,28 @@
 
 ## Overview
 
-Arithmetic is a Sugar learning activity that presents timed arithmetic questions and tracks scores on a shared scoreboard. The activity provides small puzzle modules (addition, subtraction, multiplication, division and related problems) and is implemented as a GTK/Sugar activity.
+Arithmetic is a Sugar learning activity designed to help learners practice
+basic arithmetic concepts through interactive challenges. The activity covers
+addition, subtraction, multiplication, and division, and includes score-based
+progress tracking.
 
 ## Repository Contents
 
-- `arithmetic.py`: main activity implementation (UI, question scheduling, scoring, synchronization).
-- `activity/`: activity metadata (activity.info).
-- `puzzles/`: individual puzzle modules; each module provides a `get_problem(self, difficulty)` function.
-- `dobject/`: helper modules used by the activity (UI and synchronization helpers).
+- `arithmetic.py`: main activity implementation.
+- `activity/`: activity metadata and configuration files.
+- `puzzles/`: modules defining different types of arithmetic problems.
+- `dobject/`: helper modules used by the activity.
 - `po/`: translation files for multiple languages.
-- `setup.py`, `MANIFEST`, `NEWS`, `COPYING`, `COPYING.GPLv2`: packaging and licensing metadata.
-- `screenshots/`: example images used in the repository.
+- `setup.py`, `MANIFEST`, `NEWS`, `COPYING`, `COPYING.GPLv2`: packaging and
+  licensing metadata.
+- `screenshots/`: example images included in the repository.
 
 ## Usage
 
-This project is a Sugar activity and runs inside the Sugar learning environment as an activity bundle.
+This project is a Sugar activity and is intended to run inside the Sugar learning
+environment as an activity bundle.
 
 ## License
 
-This project is distributed under the terms of the GNU General Public License (GPL), see COPYING for details. The repository contains a GPL v2 license copy.
+This project is distributed under the terms of the GNU General Public License
+(GPL) v2 or later. See the COPYING file for details.


### PR DESCRIPTION
This PR adds a minimal README describing the Arithmetic Sugar activity based on
the existing repository structure and metadata.

Closes #8
